### PR TITLE
Update default AnalyticsDomain instance type

### DIFF
--- a/pipelines/event-search-analytics-pipeline/template.yml
+++ b/pipelines/event-search-analytics-pipeline/template.yml
@@ -270,9 +270,9 @@ Resources:
       ElasticsearchClusterConfig:
         InstanceCount: 2
         ZoneAwarenessEnabled: true
-        InstanceType: m3.medium.elasticsearch
+        InstanceType: t2.medium.elasticsearch
         DedicatedMasterEnabled: true
-        DedicatedMasterType: m3.medium.elasticsearch
+        DedicatedMasterType: t2.medium.elasticsearch
         DedicatedMasterCount: 3
       EBSOptions:
         EBSEnabled: true


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
*m3.medium.elasticsearch* is now a deprecated instance type. Migrating to *t2.medium.elasticsearch*. This is a supported type per [Amazon Elasticsearch Service pricing](https://aws.amazon.com/elasticsearch-service/pricing/).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
